### PR TITLE
Add time-based triggers and update Android target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# talk-to-me
-Simple Android app that informs you by TTS when certain triggers are fired
+# Talk-to-me
+
+This is a sample Android application implementing the basic structure described in `spec.md`.
+The app is written in Kotlin using Jetpack Compose and Room. It allows creating
+"Talks" that contain a message to be spoken aloud when triggered.
+
+The project provides:
+
+* Room database and DAO for persisting `Talk` entities.
+* ViewModel and repository using Hilt for dependency injection.
+* Simple Compose UI with a list of Talks and a form to add a new Talk.
+* Text‑to‑Speech manager to speak messages.
+* Time‑based triggers scheduled with `AlarmManager` and delivered via a
+  foreground service.
+* Boot receiver that restores active Talks after device reboot.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("kotlin-kapt")
+    id("dagger.hilt.android.plugin")
+}
+
+android {
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.example.talktome"
+        minSdk = 33
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.compose.ui:ui:1.5.0")
+    implementation("androidx.compose.material3:material3:1.1.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    implementation("androidx.room:room-runtime:2.6.0")
+    kapt("androidx.room:room-compiler:2.6.0")
+    implementation("androidx.room:room-ktx:2.6.0")
+
+    implementation("com.google.dagger:hilt-android:2.48")
+    kapt("com.google.dagger:hilt-compiler:2.48")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<manifest package="com.example.talktome" xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <application
+        android:name=".TalkToMeApplication"
+        android:allowBackup="true"
+        android:label="Talk-to-me"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <receiver android:name=".ReminderReceiver" android:exported="false" />
+        <receiver android:name=".BootReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        <service
+            android:name=".TtsService"
+            android:exported="false" />
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/talktome/AddTalkScreen.kt
+++ b/app/src/main/java/com/example/talktome/AddTalkScreen.kt
@@ -1,0 +1,44 @@
+package com.example.talktome
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AddTalkScreen(
+    onSave: (String, Int) -> Unit,
+    onCancel: () -> Unit
+) {
+    var message by remember { mutableStateOf("") }
+    var interval by remember { mutableStateOf("15") }
+    Column(modifier = Modifier.padding(16.dp)) {
+        TopAppBar(title = { Text("Add Talk") })
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(
+            value = message,
+            onValueChange = { message = it },
+            label = { Text("Message to Speak") }
+        )
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(
+            value = interval,
+            onValueChange = { interval = it },
+            label = { Text("Interval minutes") }
+        )
+        Spacer(Modifier.height(16.dp))
+        Row {
+            Button(onClick = { onSave(message, interval.toIntOrNull() ?: 15) }) {
+                Text("Save")
+            }
+            Spacer(Modifier.width(8.dp))
+            Button(onClick = onCancel) {
+                Text("Cancel")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/talktome/AppDatabase.kt
+++ b/app/src/main/java/com/example/talktome/AppDatabase.kt
@@ -1,0 +1,9 @@
+package com.example.talktome
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [Talk::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun talkDao(): TalkDao
+}

--- a/app/src/main/java/com/example/talktome/AppModule.kt
+++ b/app/src/main/java/com/example/talktome/AppModule.kt
@@ -1,0 +1,26 @@
+package com.example.talktome
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, "talks.db").build()
+
+    @Provides
+    fun provideTalkDao(db: AppDatabase): TalkDao = db.talkDao()
+
+    @Provides
+    @Singleton
+    fun provideScheduler(@ApplicationContext context: Context): TalkScheduler = TalkScheduler(context)
+}

--- a/app/src/main/java/com/example/talktome/BootReceiver.kt
+++ b/app/src/main/java/com/example/talktome/BootReceiver.kt
@@ -1,0 +1,26 @@
+package com.example.talktome
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class BootReceiver : BroadcastReceiver() {
+    @Inject lateinit var repository: TalkRepository
+    @Inject lateinit var scheduler: TalkScheduler
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            // Re-schedule all enabled talks
+            CoroutineScope(Dispatchers.Default).launch {
+                repository.talks.first().filter { it.enabled }.forEach { scheduler.schedule(it) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/talktome/MainActivity.kt
+++ b/app/src/main/java/com/example/talktome/MainActivity.kt
@@ -1,0 +1,19 @@
+package com.example.talktome
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Text
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TalkToMeTheme {
+                TalkListScreen()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/talktome/ReminderReceiver.kt
+++ b/app/src/main/java/com/example/talktome/ReminderReceiver.kt
@@ -1,0 +1,19 @@
+package com.example.talktome
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+
+class ReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val message = intent.getStringExtra(EXTRA_MESSAGE) ?: return
+        val service = Intent(context, TtsService::class.java).apply {
+            putExtra(EXTRA_MESSAGE, message)
+        }
+        ContextCompat.startForegroundService(context, service)
+    }
+    companion object {
+        const val EXTRA_MESSAGE = "message"
+    }
+}

--- a/app/src/main/java/com/example/talktome/Talk.kt
+++ b/app/src/main/java/com/example/talktome/Talk.kt
@@ -1,0 +1,25 @@
+package com.example.talktome
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "talks")
+data class Talk(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val message: String,
+    val enabled: Boolean = true,
+    val triggerType: TriggerType = TriggerType.TIME_INTERVAL,
+    val intervalMinutes: Int? = null,
+    val specificTimeMillis: Long? = null,
+    val locationName: String? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val radius: Float? = null,
+    val onEnter: Boolean? = null
+)
+
+enum class TriggerType {
+    TIME_INTERVAL,
+    TIME_SPECIFIC,
+    LOCATION
+}

--- a/app/src/main/java/com/example/talktome/TalkDao.kt
+++ b/app/src/main/java/com/example/talktome/TalkDao.kt
@@ -1,0 +1,19 @@
+package com.example.talktome
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TalkDao {
+    @Query("SELECT * FROM talks")
+    fun getAll(): Flow<List<Talk>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(talk: Talk): Long
+
+    @Delete
+    suspend fun delete(talk: Talk)
+
+    @Update
+    suspend fun update(talk: Talk)
+}

--- a/app/src/main/java/com/example/talktome/TalkListScreen.kt
+++ b/app/src/main/java/com/example/talktome/TalkListScreen.kt
@@ -1,0 +1,66 @@
+package com.example.talktome
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun TalkListScreen(viewModel: TalkViewModel = hiltViewModel()) {
+    val talks by viewModel.talks.collectAsState()
+    var adding by remember { mutableStateOf(false) }
+
+    if (adding) {
+        AddTalkScreen(
+            onSave = { msg, interval ->
+                viewModel.addTalk(msg, interval)
+                adding = false
+            },
+            onCancel = { adding = false }
+        )
+    } else {
+        Scaffold(
+            floatingActionButton = {
+                FloatingActionButton(onClick = { adding = true }) {
+                    Icon(Icons.Default.Add, contentDescription = "Add")
+                }
+            }
+        ) { padding ->
+            LazyColumn(modifier = Modifier.padding(padding)) {
+                items(talks) { talk ->
+                    TalkRow(
+                        talk,
+                        onToggle = { viewModel.toggleEnabled(talk, it) },
+                        onClick = { viewModel.speak(talk) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TalkRow(talk: Talk, onToggle: (Boolean) -> Unit, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = talk.message)
+            Text(text = talk.triggerType.name)
+        }
+        Switch(checked = talk.enabled, onCheckedChange = onToggle)
+    }
+}

--- a/app/src/main/java/com/example/talktome/TalkRepository.kt
+++ b/app/src/main/java/com/example/talktome/TalkRepository.kt
@@ -1,0 +1,15 @@
+package com.example.talktome
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TalkRepository @Inject constructor(private val dao: TalkDao) {
+    val talks = dao.getAll()
+
+    suspend fun add(talk: Talk): Long = dao.insert(talk)
+
+    suspend fun delete(talk: Talk) = dao.delete(talk)
+
+    suspend fun update(talk: Talk) = dao.update(talk)
+}

--- a/app/src/main/java/com/example/talktome/TalkScheduler.kt
+++ b/app/src/main/java/com/example/talktome/TalkScheduler.kt
@@ -1,0 +1,48 @@
+package com.example.talktome
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TalkScheduler @Inject constructor(@ApplicationContext private val context: Context) {
+    private val alarmManager = context.getSystemService(AlarmManager::class.java)
+
+    fun schedule(talk: Talk) {
+        val pi = pendingIntent(talk)
+        when (talk.triggerType) {
+            TriggerType.TIME_INTERVAL -> {
+                val interval = (talk.intervalMinutes ?: return) * 60 * 1000L
+                val at = System.currentTimeMillis() + interval
+                alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, at, interval, pi)
+            }
+            TriggerType.TIME_SPECIFIC -> {
+                val time = talk.specificTimeMillis ?: return
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, time, pi)
+            }
+            TriggerType.LOCATION -> {
+                // location not implemented
+            }
+        }
+    }
+
+    fun cancel(talk: Talk) {
+        alarmManager.cancel(pendingIntent(talk))
+    }
+
+    private fun pendingIntent(talk: Talk): PendingIntent {
+        val intent = Intent(context, ReminderReceiver::class.java).apply {
+            putExtra(ReminderReceiver.EXTRA_MESSAGE, talk.message)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            talk.id.toInt(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+}

--- a/app/src/main/java/com/example/talktome/TalkToMeApplication.kt
+++ b/app/src/main/java/com/example/talktome/TalkToMeApplication.kt
@@ -1,0 +1,7 @@
+package com.example.talktome
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class TalkToMeApplication : Application()

--- a/app/src/main/java/com/example/talktome/TalkViewModel.kt
+++ b/app/src/main/java/com/example/talktome/TalkViewModel.kt
@@ -1,0 +1,49 @@
+package com.example.talktome
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TalkViewModel @Inject constructor(
+    private val repository: TalkRepository,
+    private val scheduler: TalkScheduler,
+    private val tts: TtsManager
+) : ViewModel() {
+    val talks: StateFlow<List<Talk>> = repository.talks.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyList()
+    )
+
+    fun addTalk(message: String, intervalMinutes: Int) {
+        viewModelScope.launch {
+            val talk = Talk(message = message, intervalMinutes = intervalMinutes)
+            val id = repository.add(talk)
+            scheduler.schedule(talk.copy(id = id))
+        }
+    }
+    fun speak(talk: Talk) {
+        tts.speak(talk.message)
+    }
+
+    fun deleteTalk(talk: Talk) {
+        viewModelScope.launch {
+            repository.delete(talk)
+            scheduler.cancel(talk)
+        }
+    }
+
+    fun toggleEnabled(talk: Talk, enabled: Boolean) {
+        viewModelScope.launch {
+            val updated = talk.copy(enabled = enabled)
+            repository.update(updated)
+            if (enabled) scheduler.schedule(updated) else scheduler.cancel(updated)
+        }
+    }
+}

--- a/app/src/main/java/com/example/talktome/Theme.kt
+++ b/app/src/main/java/com/example/talktome/Theme.kt
@@ -1,0 +1,11 @@
+package com.example.talktome
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+@Composable
+fun TalkToMeTheme(content: @Composable () -> Unit) {
+    val colors = darkColorScheme()
+    MaterialTheme(colorScheme = colors, content = content)
+}

--- a/app/src/main/java/com/example/talktome/TtsManager.kt
+++ b/app/src/main/java/com/example/talktome/TtsManager.kt
@@ -1,0 +1,28 @@
+package com.example.talktome
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Locale
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TtsManager @Inject constructor(@ApplicationContext context: Context) : TextToSpeech.OnInitListener {
+    private val tts = TextToSpeech(context, this)
+    private var ready = false
+
+    override fun onInit(status: Int) {
+        if (status == TextToSpeech.SUCCESS) {
+            tts.language = Locale.getDefault()
+            ready = true
+        }
+    }
+
+    fun speak(text: String) {
+        if (ready) {
+            tts.speak(text, TextToSpeech.QUEUE_ADD, null, UUID.randomUUID().toString())
+        }
+    }
+}

--- a/app/src/main/java/com/example/talktome/TtsService.kt
+++ b/app/src/main/java/com/example/talktome/TtsService.kt
@@ -1,0 +1,49 @@
+package com.example.talktome
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class TtsService : Service() {
+    @Inject lateinit var tts: TtsManager
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val message = intent?.getStringExtra(ReminderReceiver.EXTRA_MESSAGE) ?: ""
+        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle("Talk-to-me")
+            .setContentText(message)
+            .build()
+        startForeground(1, notification)
+        tts.speak(message)
+        stopForeground(STOP_FOREGROUND_DETACH)
+        stopSelf()
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createChannel() {
+        val nm = getSystemService(NotificationManager::class.java)
+        if (nm.getNotificationChannel(CHANNEL_ID) == null) {
+            val channel = NotificationChannel(CHANNEL_ID, "Talks", NotificationManager.IMPORTANCE_LOW)
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val CHANNEL_ID = "talks"
+    }
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.TalkToMe" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="31">?attr/colorPrimary</item>
+    </style>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,18 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
+        classpath("com.google.dagger:hilt-android-gradle-plugin:2.48")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include(":app")


### PR DESCRIPTION
## Summary
- set compile and target SDK to 35
- introduce `TalkScheduler` using `AlarmManager`
- run TTS in a foreground `TtsService`
- register `ReminderReceiver` and boot rescheduling
- implement basic add screen and talk list interactions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e603b9c008331bb5b9c581c38a34d