### PR TITLE
Add delete talk feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ The project provides:
 * Time‑based triggers scheduled with `AlarmManager` and delivered via a
   foreground service.
 * Boot receiver that restores active Talks after device reboot.
+* Delete Talks from the list via a long‑press gesture.

--- a/app/src/main/java/com/example/talktome/TalkListScreen.kt
+++ b/app/src/main/java/com/example/talktome/TalkListScreen.kt
@@ -1,6 +1,6 @@
 package com.example.talktome
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -18,6 +18,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 fun TalkListScreen(viewModel: TalkViewModel = hiltViewModel()) {
     val talks by viewModel.talks.collectAsState()
     var adding by remember { mutableStateOf(false) }
+    var deleting by remember { mutableStateOf<Talk?>(null) }
 
     if (adding) {
         AddTalkScreen(
@@ -40,20 +41,46 @@ fun TalkListScreen(viewModel: TalkViewModel = hiltViewModel()) {
                     TalkRow(
                         talk,
                         onToggle = { viewModel.toggleEnabled(talk, it) },
-                        onClick = { viewModel.speak(talk) }
+                        onClick = { viewModel.speak(talk) },
+                        onLongPress = { deleting = talk }
                     )
                 }
             }
+        }
+        deleting?.let { talk ->
+            AlertDialog(
+                onDismissRequest = { deleting = null },
+                title = { Text("Delete Talk") },
+                text = { Text("Delete '${'$'}{talk.message}'?") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        viewModel.deleteTalk(talk)
+                        deleting = null
+                    }) {
+                        Text("Delete")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { deleting = null }) {
+                        Text("Cancel")
+                    }
+                }
+            )
         }
     }
 }
 
 @Composable
-fun TalkRow(talk: Talk, onToggle: (Boolean) -> Unit, onClick: () -> Unit) {
+fun TalkRow(
+    talk: Talk,
+    onToggle: (Boolean) -> Unit,
+    onClick: () -> Unit,
+    onLongPress: () -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .combinedClickable(onClick = onClick, onLongClick = onLongPress)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {


### PR DESCRIPTION
## Summary
- allow deleting a talk from the list with a long-press
- mention delete feature in README

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e6606de2c8331b72d11ca2e4b67cb