### PR TITLE
Add TalkDao unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,4 +49,9 @@ dependencies {
 
     implementation("com.google.dagger:hilt-android:2.48")
     kapt("com.google.dagger:hilt-compiler:2.48")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.room:room-testing:2.6.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("androidx.test:core:1.5.0")
 }

--- a/app/src/test/java/com/example/talktome/TalkDaoTest.kt
+++ b/app/src/test/java/com/example/talktome/TalkDaoTest.kt
@@ -1,0 +1,48 @@
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class TalkDaoTest {
+    private lateinit var db: AppDatabase
+    private lateinit var dao: TalkDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.talkDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertAndRetrieveTalk() = runTest {
+        val talk = Talk(message = "hello")
+        val id = dao.insert(talk)
+        val talks = dao.getAll().first()
+        assertEquals(1, talks.size)
+        assertEquals(id, talks[0].id)
+        assertEquals("hello", talks[0].message)
+    }
+
+    @Test
+    fun deleteTalkRemovesIt() = runTest {
+        val talk = Talk(message = "bye")
+        val id = dao.insert(talk)
+        dao.delete(talk.copy(id = id))
+        val talks = dao.getAll().first()
+        assertTrue(talks.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for storing and retrieving Talks
- verify deletion behaviour
- add necessary test libraries

## Testing
- `gradle test --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e694b07dc83318731d94511c672c9