### PR TITLE
Implement queued speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The project provides:
 * Room database and DAO for persisting `Talk` entities.
 * ViewModel and repository using Hilt for dependency injection.
 * Simple Compose UI with a list of Talks and a form to add a new Talk.
-* Text‑to‑Speech manager to speak messages.
+* Text‑to‑Speech manager to speak messages. Speech requests are queued so that
+  multiple Talks triggered at the same time are spoken one after another.
 * Time‑based triggers scheduled with `AlarmManager` and delivered via a
   foreground service.
 * Boot receiver that restores active Talks after device reboot.

--- a/app/src/main/java/com/example/talktome/TtsManager.kt
+++ b/app/src/main/java/com/example/talktome/TtsManager.kt
@@ -12,17 +12,25 @@ import javax.inject.Singleton
 class TtsManager @Inject constructor(@ApplicationContext context: Context) : TextToSpeech.OnInitListener {
     private val tts = TextToSpeech(context, this)
     private var ready = false
+    private val pending = mutableListOf<String>()
 
     override fun onInit(status: Int) {
         if (status == TextToSpeech.SUCCESS) {
             tts.language = Locale.getDefault()
             ready = true
+            // Flush any messages that arrived before initialization completed
+            pending.forEach { text ->
+                tts.speak(text, TextToSpeech.QUEUE_ADD, null, UUID.randomUUID().toString())
+            }
+            pending.clear()
         }
     }
 
     fun speak(text: String) {
         if (ready) {
             tts.speak(text, TextToSpeech.QUEUE_ADD, null, UUID.randomUUID().toString())
+        } else {
+            pending.add(text)
         }
     }
 }


### PR DESCRIPTION
## Summary
- queue TTS calls in `TtsManager` until initialization finishes
- document that TTS speech is queued

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ecae4eb448331a7fc6994caf358f2