### PR TITLE
Add debug logging across app

### DIFF
--- a/app/src/main/java/com/example/talktome/AddTalkScreen.kt
+++ b/app/src/main/java/com/example/talktome/AddTalkScreen.kt
@@ -8,12 +8,14 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import android.util.Log
 
 @Composable
 fun AddTalkScreen(
     onSave: (String, Int) -> Unit,
     onCancel: () -> Unit
 ) {
+    Log.d(TAG, "AddTalkScreen called")
     var message by remember { mutableStateOf("") }
     var interval by remember { mutableStateOf("15") }
     Column(modifier = Modifier.padding(16.dp)) {
@@ -42,3 +44,5 @@ fun AddTalkScreen(
         }
     }
 }
+
+private const val TAG = "AddTalkScreen"

--- a/app/src/main/java/com/example/talktome/AppModule.kt
+++ b/app/src/main/java/com/example/talktome/AppModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+import android.util.Log
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -15,12 +16,20 @@ object AppModule {
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
-        Room.databaseBuilder(context, AppDatabase::class.java, "talks.db").build()
+        Room.databaseBuilder(context, AppDatabase::class.java, "talks.db").build().also {
+            Log.d(TAG, "provideDatabase")
+        }
 
     @Provides
-    fun provideTalkDao(db: AppDatabase): TalkDao = db.talkDao()
+    fun provideTalkDao(db: AppDatabase): TalkDao = db.talkDao().also {
+        Log.d(TAG, "provideTalkDao")
+    }
 
     @Provides
     @Singleton
-    fun provideScheduler(@ApplicationContext context: Context): TalkScheduler = TalkScheduler(context)
+    fun provideScheduler(@ApplicationContext context: Context): TalkScheduler = TalkScheduler(context).also {
+        Log.d(TAG, "provideScheduler")
+    }
 }
+
+private const val TAG = "AppModule"

--- a/app/src/main/java/com/example/talktome/BootReceiver.kt
+++ b/app/src/main/java/com/example/talktome/BootReceiver.kt
@@ -3,6 +3,7 @@ package com.example.talktome
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,11 +17,15 @@ class BootReceiver : BroadcastReceiver() {
     @Inject lateinit var scheduler: TalkScheduler
 
     override fun onReceive(context: Context, intent: Intent) {
+        Log.d(TAG, "onReceive action=${'$'}{intent.action}")
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
             // Re-schedule all enabled talks
             CoroutineScope(Dispatchers.Default).launch {
                 repository.talks.first().filter { it.enabled }.forEach { scheduler.schedule(it) }
             }
         }
+    }
+    companion object {
+        private const val TAG = "BootReceiver"
     }
 }

--- a/app/src/main/java/com/example/talktome/MainActivity.kt
+++ b/app/src/main/java/com/example/talktome/MainActivity.kt
@@ -5,11 +5,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.Text
 import dagger.hilt.android.AndroidEntryPoint
+import android.util.Log
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.d(TAG, "onCreate")
         setContent {
             TalkToMeTheme {
                 TalkListScreen()
@@ -17,3 +19,5 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
+
+private const val TAG = "MainActivity"

--- a/app/src/main/java/com/example/talktome/ReminderReceiver.kt
+++ b/app/src/main/java/com/example/talktome/ReminderReceiver.kt
@@ -4,10 +4,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.core.content.ContextCompat
+import android.util.Log
 
 class ReminderReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val message = intent.getStringExtra(EXTRA_MESSAGE) ?: return
+        Log.d(TAG, "onReceive message=${'$'}message")
         val service = Intent(context, TtsService::class.java).apply {
             putExtra(EXTRA_MESSAGE, message)
         }
@@ -15,5 +17,6 @@ class ReminderReceiver : BroadcastReceiver() {
     }
     companion object {
         const val EXTRA_MESSAGE = "message"
+        private const val TAG = "ReminderReceiver"
     }
 }

--- a/app/src/main/java/com/example/talktome/TalkListScreen.kt
+++ b/app/src/main/java/com/example/talktome/TalkListScreen.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import android.util.Log
 
 @Composable
 fun TalkListScreen(viewModel: TalkViewModel = hiltViewModel()) {
+    Log.d(TAG, "TalkListScreen called")
     val talks by viewModel.talks.collectAsState()
     var adding by remember { mutableStateOf(false) }
     var deleting by remember { mutableStateOf<Talk?>(null) }
@@ -77,6 +79,7 @@ fun TalkRow(
     onClick: () -> Unit,
     onLongPress: () -> Unit
 ) {
+    Log.d(TAG, "TalkRow called for talk=${'$'}{talk.id}")
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -91,3 +94,5 @@ fun TalkRow(
         Switch(checked = talk.enabled, onCheckedChange = onToggle)
     }
 }
+
+private const val TAG = "TalkListScreen"

--- a/app/src/main/java/com/example/talktome/TalkRepository.kt
+++ b/app/src/main/java/com/example/talktome/TalkRepository.kt
@@ -2,14 +2,28 @@ package com.example.talktome
 
 import javax.inject.Inject
 import javax.inject.Singleton
+import android.util.Log
 
 @Singleton
 class TalkRepository @Inject constructor(private val dao: TalkDao) {
     val talks = dao.getAll()
 
-    suspend fun add(talk: Talk): Long = dao.insert(talk)
+    suspend fun add(talk: Talk): Long {
+        Log.d(TAG, "add talk=${'$'}talk")
+        return dao.insert(talk)
+    }
 
-    suspend fun delete(talk: Talk) = dao.delete(talk)
+    suspend fun delete(talk: Talk) {
+        Log.d(TAG, "delete talk=${'$'}talk")
+        dao.delete(talk)
+    }
 
-    suspend fun update(talk: Talk) = dao.update(talk)
+    suspend fun update(talk: Talk) {
+        Log.d(TAG, "update talk=${'$'}talk")
+        dao.update(talk)
+    }
+
+    companion object {
+        private const val TAG = "TalkRepository"
+    }
 }

--- a/app/src/main/java/com/example/talktome/TalkScheduler.kt
+++ b/app/src/main/java/com/example/talktome/TalkScheduler.kt
@@ -7,12 +7,14 @@ import android.content.Intent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import android.util.Log
 
 @Singleton
 class TalkScheduler @Inject constructor(@ApplicationContext private val context: Context) {
     private val alarmManager = context.getSystemService(AlarmManager::class.java)
 
     fun schedule(talk: Talk) {
+        Log.d(TAG, "schedule talk=${'$'}talk")
         val pi = pendingIntent(talk)
         when (talk.triggerType) {
             TriggerType.TIME_INTERVAL -> {
@@ -31,10 +33,12 @@ class TalkScheduler @Inject constructor(@ApplicationContext private val context:
     }
 
     fun cancel(talk: Talk) {
+        Log.d(TAG, "cancel talk=${'$'}talk")
         alarmManager.cancel(pendingIntent(talk))
     }
 
     private fun pendingIntent(talk: Talk): PendingIntent {
+        Log.d(TAG, "pendingIntent for talk=${'$'}talk")
         val intent = Intent(context, ReminderReceiver::class.java).apply {
             putExtra(ReminderReceiver.EXTRA_MESSAGE, talk.message)
         }
@@ -44,5 +48,9 @@ class TalkScheduler @Inject constructor(@ApplicationContext private val context:
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+    }
+
+    companion object {
+        private const val TAG = "TalkScheduler"
     }
 }

--- a/app/src/main/java/com/example/talktome/TalkToMeApplication.kt
+++ b/app/src/main/java/com/example/talktome/TalkToMeApplication.kt
@@ -2,6 +2,16 @@ package com.example.talktome
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import android.util.Log
 
 @HiltAndroidApp
-class TalkToMeApplication : Application()
+class TalkToMeApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "onCreate")
+    }
+
+    companion object {
+        private const val TAG = "TalkToMeApp"
+    }
+}

--- a/app/src/main/java/com/example/talktome/TalkViewModel.kt
+++ b/app/src/main/java/com/example/talktome/TalkViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import android.util.Log
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -22,6 +23,7 @@ class TalkViewModel @Inject constructor(
     )
 
     fun addTalk(message: String, intervalMinutes: Int) {
+        Log.d(TAG, "addTalk message=${'$'}message interval=${'$'}intervalMinutes")
         viewModelScope.launch {
             val talk = Talk(message = message, intervalMinutes = intervalMinutes)
             val id = repository.add(talk)
@@ -29,10 +31,12 @@ class TalkViewModel @Inject constructor(
         }
     }
     fun speak(talk: Talk) {
+        Log.d(TAG, "speak talk=${'$'}talk")
         tts.speak(talk.message)
     }
 
     fun deleteTalk(talk: Talk) {
+        Log.d(TAG, "deleteTalk talk=${'$'}talk")
         viewModelScope.launch {
             repository.delete(talk)
             scheduler.cancel(talk)
@@ -40,10 +44,14 @@ class TalkViewModel @Inject constructor(
     }
 
     fun toggleEnabled(talk: Talk, enabled: Boolean) {
+        Log.d(TAG, "toggleEnabled talk=${'$'}talk enabled=${'$'}enabled")
         viewModelScope.launch {
             val updated = talk.copy(enabled = enabled)
             repository.update(updated)
             if (enabled) scheduler.schedule(updated) else scheduler.cancel(updated)
         }
+    }
+    companion object {
+        private const val TAG = "TalkViewModel"
     }
 }

--- a/app/src/main/java/com/example/talktome/Theme.kt
+++ b/app/src/main/java/com/example/talktome/Theme.kt
@@ -3,9 +3,13 @@ package com.example.talktome
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import android.util.Log
 
 @Composable
 fun TalkToMeTheme(content: @Composable () -> Unit) {
+    Log.d(TAG, "TalkToMeTheme")
     val colors = darkColorScheme()
     MaterialTheme(colorScheme = colors, content = content)
 }
+
+private const val TAG = "Theme"

--- a/app/src/main/java/com/example/talktome/TtsManager.kt
+++ b/app/src/main/java/com/example/talktome/TtsManager.kt
@@ -7,6 +7,7 @@ import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
+import android.util.Log
 
 @Singleton
 class TtsManager @Inject constructor(@ApplicationContext context: Context) : TextToSpeech.OnInitListener {
@@ -15,6 +16,7 @@ class TtsManager @Inject constructor(@ApplicationContext context: Context) : Tex
     private val pending = mutableListOf<String>()
 
     override fun onInit(status: Int) {
+        Log.d(TAG, "onInit status=${'$'}status")
         if (status == TextToSpeech.SUCCESS) {
             tts.language = Locale.getDefault()
             ready = true
@@ -27,10 +29,15 @@ class TtsManager @Inject constructor(@ApplicationContext context: Context) : Tex
     }
 
     fun speak(text: String) {
+        Log.d(TAG, "speak text=${'$'}text ready=${'$'}ready")
         if (ready) {
             tts.speak(text, TextToSpeech.QUEUE_ADD, null, UUID.randomUUID().toString())
         } else {
             pending.add(text)
         }
+    }
+
+    companion object {
+        private const val TAG = "TtsManager"
     }
 }

--- a/app/src/main/java/com/example/talktome/TtsService.kt
+++ b/app/src/main/java/com/example/talktome/TtsService.kt
@@ -9,6 +9,7 @@ import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import android.util.Log
 
 @AndroidEntryPoint
 class TtsService : Service() {
@@ -16,11 +17,13 @@ class TtsService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        Log.d(TAG, "onCreate")
         createChannel()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val message = intent?.getStringExtra(ReminderReceiver.EXTRA_MESSAGE) ?: ""
+        Log.d(TAG, "onStartCommand message=${'$'}message")
         val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setContentTitle("Talk-to-me")
@@ -36,6 +39,7 @@ class TtsService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun createChannel() {
+        Log.d(TAG, "createChannel")
         val nm = getSystemService(NotificationManager::class.java)
         if (nm.getNotificationChannel(CHANNEL_ID) == null) {
             val channel = NotificationChannel(CHANNEL_ID, "Talks", NotificationManager.IMPORTANCE_LOW)
@@ -45,5 +49,6 @@ class TtsService : Service() {
 
     companion object {
         const val CHANNEL_ID = "talks"
+        private const val TAG = "TtsService"
     }
 }


### PR DESCRIPTION
## Summary
- log key lifecycle events in `MainActivity`
- add debug logs to Compose screens, services, and receivers
- add provider logs in `AppModule`
- record repository and scheduler operations
- log TTS manager initialization and usage

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684edfc9b3508331869cdc7974682c94